### PR TITLE
[codex] Adjust blog reading aid spacing

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -288,6 +288,27 @@ body.sticky-bottom-footer {
       transform: translateY(0);
     }
   }
+
+  .blog-post .section-reading-aid-desktop {
+    --section-reading-aid-gap: clamp(1rem, 3vw, 3.5rem);
+    --section-reading-aid-width: clamp(11.15rem, 14vw, 13rem);
+
+    left: max(1rem, calc(50vw - (var(--measure-prose) / 2) - var(--section-reading-aid-gap) - var(--section-reading-aid-width)));
+    width: var(--section-reading-aid-width);
+
+    .section-reading-aid-link {
+      grid-template-columns: 1.35rem minmax(0, 1fr);
+      gap: 0.42rem;
+
+      &::before {
+        width: 1.2rem;
+      }
+    }
+
+    .section-reading-aid-kicker {
+      margin-left: 1.77rem;
+    }
+  }
 }
 
 @media (max-width: 1279.98px) {


### PR DESCRIPTION
## Summary

- Move the desktop blog section reading aid farther left with blog-specific responsive width and gap variables.
- Give reading-aid link labels a wider usable text column by tightening the decorative line column.
- Keep project reading aids and sub-1280 mobile/sticky behavior unchanged.

## Why

The blog side reading aid could sit too close to prose content and clip section labels more aggressively than needed. This keeps the rail clear of the content column while improving title legibility on desktop blog posts.

## Validation

- `bundle exec jekyll build --baseurl=`
- `npm run lint:style-contract`
- `npx prettier --check _sass/_layout.scss`
- `git diff --check`
- Custom Playwright layout measurements for desktop widths `1280`, `1366`, `1440`, and `1600`
- Custom Playwright mobile/sticky checks at `375`, `768`, and `1279`

## Notes

- Full `npm run lint:prettier` still reports pre-existing formatting issues in `_sass/_publications.scss` and `assets/js/publication-lens.js`, which are unrelated to this PR.
- The local visual grep is also blocked by existing desktop test expectations and missing WebKit for mobile, so I used focused layout measurements for this specific UX fix.