### PR TITLE
[codex] Refine blog reading aid breakpoint

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -290,7 +290,7 @@ body.sticky-bottom-footer {
   }
 
   .blog-post .section-reading-aid-desktop {
-    --section-reading-aid-gap: clamp(1rem, 3vw, 3.5rem);
+    --section-reading-aid-gap: clamp(1.5rem, 4vw, 4.5rem);
     --section-reading-aid-width: clamp(11.15rem, 14vw, 13rem);
 
     left: max(1rem, calc(50vw - (var(--measure-prose) / 2) - var(--section-reading-aid-gap) - var(--section-reading-aid-width)));
@@ -308,6 +308,19 @@ body.sticky-bottom-footer {
     .section-reading-aid-kicker {
       margin-left: 1.77rem;
     }
+  }
+}
+
+@media (min-width: 1280px) and (max-width: 1359.98px) {
+  .blog-post .section-reading-aid-desktop {
+    display: none;
+  }
+
+  .blog-post .section-reading-aid-mobile {
+    position: sticky;
+    top: 4.35rem;
+    z-index: 12;
+    display: block;
   }
 }
 


### PR DESCRIPTION
## Summary
- Increase the blog-only desktop reading-aid gap so the rail sits farther left at wider desktop widths.
- Hide the blog desktop rail from 1280px through 1359.98px and keep the sticky in-content reading aid active in that tight band.
- Leave project-page reading aids and `assets/js/section-reading-aid.js` unchanged.

## Validation
- `npx prettier --check _sass/_layout.scss`
- `npm run lint:style-contract`
- `bundle exec jekyll build --baseurl=`
- Browser-measured generated blog posts at `375`, `768`, `1279`, `1280`, `1320`, `1359`, `1360`, `1366`, `1440`, and `1600`.

## Browser measurement notes
- Blog pages with a section reading aid use the sticky mobile aid below `1360px`; desktop rail is hidden through `1359px`.
- At `1360px+`, the desktop rail is visible with measured prose clearance of `42px` at `1360`, `44px` at `1366`, `58px` at `1440`, and `64px` at `1600`.
- No horizontal overflow was observed across the generated blog posts.
- The requested `/blog/2023/sidebar-table-of-contents/` URL is currently unpublished (`published: false`), so generated-site browser validation used the published blog routes.